### PR TITLE
Add assurance case diagram and assessment to main document

### DIFF
--- a/Assurance-Cases-for-Software-Security-Engineering.md
+++ b/Assurance-Cases-for-Software-Security-Engineering.md
@@ -30,9 +30,11 @@
 
 ### **Claim 3 - ERPNext does not expose sensitive information in public APIs.**
 
-##Diagram here
+![Assurance Case - APIs](/api-assurance-case.png)
 
 **Part 2 Assessment**  
+
+Much of the evidence that I identified was available in the documentation both for ERPNext and the underlying Frappe framework. Github actions also provided sources of evidence. The GitHub repositories for ERPNext and the Frappe framework use automated actions that provide static code analysis with tools like Semgrep and CodeQL and check for dependencies that are out of date or have known vulnerabilities. The only evidence that required additional efforts to collect was the CVE reports for the application. Finding current CVEs requires searching external databases, but it is understandable that the developers would not publicly disclose vulnerabilities until a fix is available. Overall, the evidence for this claim is readily available.
 
 
 ----


### PR DESCRIPTION
Add the assurance claim and assessment to the main document